### PR TITLE
未実装コード解消

### DIFF
--- a/src/NonIPFileDelivery/Services/FTPAnalyzer.cs
+++ b/src/NonIPFileDelivery/Services/FTPAnalyzer.cs
@@ -101,13 +101,13 @@ namespace NonIPFileDelivery.Services
             {
                 _logger.Error($"FTP analysis failed: Text decoding error - {ex.Message}", ex);
                 result.ErrorMessage = "FTP command contains invalid characters";
-                return result;
+                return Task.FromResult(result);
             }
             catch (ArgumentException ex)
             {
                 _logger.Error($"FTP analysis failed: Invalid argument - {ex.Message}", ex);
                 result.ErrorMessage = $"Invalid FTP data format: {ex.Message}";
-                return result;
+                return Task.FromResult(result);
             }
             catch (Exception ex)
             {

--- a/src/NonIPFileDelivery/Services/FileStorageService.cs
+++ b/src/NonIPFileDelivery/Services/FileStorageService.cs
@@ -1,0 +1,357 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NonIPFileDelivery.Services;
+
+/// <summary>
+/// ファイルチャンクの保存・組み立て・検証サービス
+/// </summary>
+public class FileStorageService : IFileStorageService
+{
+    private readonly ILoggingService _logger;
+    private readonly string _tempDirectory;
+    private readonly ConcurrentDictionary<string, ChunkTracker> _chunkTrackers;
+
+    public FileStorageService(ILoggingService logger, string? tempDirectory = null)
+    {
+        _logger = logger;
+        _tempDirectory = tempDirectory ?? Path.Combine(Path.GetTempPath(), "NonIPFileDelivery", "chunks");
+        _chunkTrackers = new ConcurrentDictionary<string, ChunkTracker>();
+
+        // 一時ディレクトリを作成
+        if (!Directory.Exists(_tempDirectory))
+        {
+            Directory.CreateDirectory(_tempDirectory);
+            _logger.Info($"Created temp directory: {_tempDirectory}");
+        }
+    }
+
+    /// <summary>
+    /// ファイルチャンクを一時保存
+    /// </summary>
+    public async Task<bool> SaveChunkAsync(Guid sessionId, string fileName, int chunkIndex, int totalChunks, byte[] chunkData)
+    {
+        try
+        {
+            if (chunkData == null || chunkData.Length == 0)
+            {
+                _logger.Warning($"Empty chunk data: SessionId={sessionId}, File={fileName}, ChunkIndex={chunkIndex}");
+                return false;
+            }
+
+            // セッション用のディレクトリを作成
+            var sessionDir = Path.Combine(_tempDirectory, sessionId.ToString());
+            if (!Directory.Exists(sessionDir))
+            {
+                Directory.CreateDirectory(sessionDir);
+            }
+
+            // ファイル名をサニタイズ
+            var safeFileName = SanitizeFileName(fileName);
+            var chunkFilePath = Path.Combine(sessionDir, $"{safeFileName}.chunk_{chunkIndex:D6}");
+
+            // チャンクをファイルに保存
+            await File.WriteAllBytesAsync(chunkFilePath, chunkData);
+
+            // チャンク追跡情報を更新
+            var trackerKey = $"{sessionId}_{safeFileName}";
+            var tracker = _chunkTrackers.GetOrAdd(trackerKey, _ => new ChunkTracker
+            {
+                SessionId = sessionId,
+                FileName = safeFileName,
+                TotalChunks = totalChunks,
+                ReceivedChunks = new ConcurrentDictionary<int, bool>(),
+                LastUpdateTime = DateTime.UtcNow
+            });
+
+            tracker.ReceivedChunks[chunkIndex] = true;
+            tracker.LastUpdateTime = DateTime.UtcNow;
+
+            _logger.Debug($"Chunk saved: SessionId={sessionId}, File={fileName}, Chunk={chunkIndex}/{totalChunks}, Size={chunkData.Length} bytes");
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"Failed to save chunk: SessionId={sessionId}, File={fileName}, ChunkIndex={chunkIndex}", ex);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// 全てのチャンクが揃っているかチェック
+    /// </summary>
+    public Task<bool> AreAllChunksReceivedAsync(Guid sessionId, string fileName, int totalChunks)
+    {
+        try
+        {
+            var safeFileName = SanitizeFileName(fileName);
+            var trackerKey = $"{sessionId}_{safeFileName}";
+
+            if (!_chunkTrackers.TryGetValue(trackerKey, out var tracker))
+            {
+                _logger.Debug($"No chunks received yet: SessionId={sessionId}, File={fileName}");
+                return Task.FromResult(false);
+            }
+
+            // 0からtotalChunks-1まで全て受信済みかチェック
+            for (int i = 0; i < totalChunks; i++)
+            {
+                if (!tracker.ReceivedChunks.ContainsKey(i))
+                {
+                    _logger.Debug($"Missing chunk {i}/{totalChunks}: SessionId={sessionId}, File={fileName}");
+                    return Task.FromResult(false);
+                }
+            }
+
+            _logger.Info($"All chunks received: SessionId={sessionId}, File={fileName}, TotalChunks={totalChunks}");
+            return Task.FromResult(true);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"Error checking chunks: SessionId={sessionId}, File={fileName}", ex);
+            return Task.FromResult(false);
+        }
+    }
+
+    /// <summary>
+    /// チャンクを組み立てて最終ファイルを生成
+    /// </summary>
+    public async Task<string> AssembleFileAsync(Guid sessionId, string fileName, int totalChunks, string destinationPath)
+    {
+        try
+        {
+            var safeFileName = SanitizeFileName(fileName);
+            var sessionDir = Path.Combine(_tempDirectory, sessionId.ToString());
+
+            if (!Directory.Exists(sessionDir))
+            {
+                throw new DirectoryNotFoundException($"Session directory not found: {sessionDir}");
+            }
+
+            // 最終ファイルのディレクトリを作成
+            var destinationDir = Path.GetDirectoryName(destinationPath);
+            if (!string.IsNullOrEmpty(destinationDir) && !Directory.Exists(destinationDir))
+            {
+                Directory.CreateDirectory(destinationDir);
+            }
+
+            _logger.Info($"Assembling file: SessionId={sessionId}, File={fileName}, TotalChunks={totalChunks}");
+
+            // チャンクを順番に読み込んで結合
+            using (var outputStream = new FileStream(destinationPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true))
+            {
+                for (int i = 0; i < totalChunks; i++)
+                {
+                    var chunkFilePath = Path.Combine(sessionDir, $"{safeFileName}.chunk_{i:D6}");
+
+                    if (!File.Exists(chunkFilePath))
+                    {
+                        throw new FileNotFoundException($"Chunk file not found: {chunkFilePath}");
+                    }
+
+                    var chunkData = await File.ReadAllBytesAsync(chunkFilePath);
+                    await outputStream.WriteAsync(chunkData, 0, chunkData.Length);
+
+                    _logger.Debug($"Chunk {i}/{totalChunks} written to output file, size: {chunkData.Length} bytes");
+                }
+            }
+
+            var fileInfo = new FileInfo(destinationPath);
+            _logger.Info($"File assembled successfully: {destinationPath}, Size: {fileInfo.Length} bytes");
+
+            // チャンク追跡情報をクリーンアップ
+            var trackerKey = $"{sessionId}_{safeFileName}";
+            _chunkTrackers.TryRemove(trackerKey, out _);
+
+            return destinationPath;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"Failed to assemble file: SessionId={sessionId}, File={fileName}", ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// ファイルハッシュを検証
+    /// </summary>
+    public async Task<bool> ValidateFileHashAsync(string filePath, string expectedHash)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+            {
+                _logger.Warning($"File not found for hash validation: {filePath}");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(expectedHash))
+            {
+                _logger.Warning($"No expected hash provided for: {filePath}");
+                return true; // ハッシュが提供されていない場合は検証スキップ
+            }
+
+            _logger.Debug($"Validating file hash: {filePath}");
+
+            string actualHash;
+            using (var sha256 = SHA256.Create())
+            {
+                using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 81920, useAsync: true);
+                var hashBytes = await Task.Run(() => sha256.ComputeHash(fileStream));
+                actualHash = BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
+            }
+
+            var normalizedExpectedHash = expectedHash.Replace("-", "").ToLowerInvariant();
+            var isValid = actualHash.Equals(normalizedExpectedHash, StringComparison.OrdinalIgnoreCase);
+
+            if (isValid)
+            {
+                _logger.Info($"File hash validation passed: {filePath}");
+            }
+            else
+            {
+                _logger.Warning($"File hash validation failed: {filePath}, Expected={normalizedExpectedHash}, Actual={actualHash}");
+            }
+
+            return isValid;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"Error validating file hash: {filePath}", ex);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// セッションの一時ファイルをクリーンアップ
+    /// </summary>
+    public async Task CleanupSessionAsync(Guid sessionId)
+    {
+        try
+        {
+            var sessionDir = Path.Combine(_tempDirectory, sessionId.ToString());
+
+            if (Directory.Exists(sessionDir))
+            {
+                await Task.Run(() => Directory.Delete(sessionDir, recursive: true));
+                _logger.Info($"Session temp files cleaned up: SessionId={sessionId}");
+            }
+
+            // チャンク追跡情報をクリーンアップ
+            var keysToRemove = _chunkTrackers.Keys.Where(k => k.StartsWith(sessionId.ToString())).ToList();
+            foreach (var key in keysToRemove)
+            {
+                _chunkTrackers.TryRemove(key, out _);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"Error cleaning up session: SessionId={sessionId}", ex);
+        }
+    }
+
+    /// <summary>
+    /// 古い一時ファイルをクリーンアップ
+    /// </summary>
+    public async Task CleanupOldFilesAsync(TimeSpan olderThan)
+    {
+        try
+        {
+            if (!Directory.Exists(_tempDirectory))
+            {
+                return;
+            }
+
+            var cutoffTime = DateTime.UtcNow - olderThan;
+            var deletedCount = 0;
+
+            await Task.Run(() =>
+            {
+                var sessionDirs = Directory.GetDirectories(_tempDirectory);
+
+                foreach (var sessionDir in sessionDirs)
+                {
+                    var dirInfo = new DirectoryInfo(sessionDir);
+
+                    if (dirInfo.LastWriteTimeUtc < cutoffTime)
+                    {
+                        try
+                        {
+                            dirInfo.Delete(recursive: true);
+                            deletedCount++;
+                            _logger.Debug($"Deleted old session directory: {sessionDir}");
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.Warning($"Failed to delete old session directory: {sessionDir}: {ex.Message}");
+                        }
+                    }
+                }
+            });
+
+            // 古いチャンク追跡情報をクリーンアップ
+            var keysToRemove = _chunkTrackers
+                .Where(kvp => kvp.Value.LastUpdateTime < cutoffTime)
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            foreach (var key in keysToRemove)
+            {
+                _chunkTrackers.TryRemove(key, out _);
+            }
+
+            if (deletedCount > 0)
+            {
+                _logger.Info($"Cleaned up {deletedCount} old session directories");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("Error cleaning up old files", ex);
+        }
+    }
+
+    /// <summary>
+    /// ファイル名をサニタイズ（安全なファイル名に変換）
+    /// </summary>
+    private string SanitizeFileName(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return "unnamed_file";
+        }
+
+        // 無効な文字を置換
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var sanitized = new StringBuilder(fileName);
+
+        foreach (var c in invalidChars)
+        {
+            sanitized.Replace(c, '_');
+        }
+
+        // パス区切り文字も置換
+        sanitized.Replace('/', '_');
+        sanitized.Replace('\\', '_');
+
+        return sanitized.ToString();
+    }
+
+    /// <summary>
+    /// チャンク追跡情報
+    /// </summary>
+    private class ChunkTracker
+    {
+        public Guid SessionId { get; set; }
+        public string FileName { get; set; } = string.Empty;
+        public int TotalChunks { get; set; }
+        public ConcurrentDictionary<int, bool> ReceivedChunks { get; set; } = new();
+        public DateTime LastUpdateTime { get; set; }
+    }
+}

--- a/src/NonIPFileDelivery/Services/IFileStorageService.cs
+++ b/src/NonIPFileDelivery/Services/IFileStorageService.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading.Tasks;
+
+namespace NonIPFileDelivery.Services;
+
+/// <summary>
+/// ファイルチャンクの保存・組み立て・検証を行うサービス
+/// </summary>
+public interface IFileStorageService
+{
+    /// <summary>
+    /// ファイルチャンクを一時保存
+    /// </summary>
+    /// <param name="sessionId">セッションID</param>
+    /// <param name="fileName">ファイル名</param>
+    /// <param name="chunkIndex">チャンクインデックス</param>
+    /// <param name="totalChunks">総チャンク数</param>
+    /// <param name="chunkData">チャンクデータ</param>
+    /// <returns>保存成功時はtrue</returns>
+    Task<bool> SaveChunkAsync(Guid sessionId, string fileName, int chunkIndex, int totalChunks, byte[] chunkData);
+
+    /// <summary>
+    /// 全てのチャンクが揃っているかチェック
+    /// </summary>
+    /// <param name="sessionId">セッションID</param>
+    /// <param name="fileName">ファイル名</param>
+    /// <param name="totalChunks">総チャンク数</param>
+    /// <returns>全て揃っている場合はtrue</returns>
+    Task<bool> AreAllChunksReceivedAsync(Guid sessionId, string fileName, int totalChunks);
+
+    /// <summary>
+    /// チャンクを組み立てて最終ファイルを生成
+    /// </summary>
+    /// <param name="sessionId">セッションID</param>
+    /// <param name="fileName">ファイル名</param>
+    /// <param name="totalChunks">総チャンク数</param>
+    /// <param name="destinationPath">最終ファイルの保存先パス</param>
+    /// <returns>組み立てられたファイルのパス</returns>
+    Task<string> AssembleFileAsync(Guid sessionId, string fileName, int totalChunks, string destinationPath);
+
+    /// <summary>
+    /// ファイルハッシュを検証
+    /// </summary>
+    /// <param name="filePath">ファイルパス</param>
+    /// <param name="expectedHash">期待されるハッシュ値</param>
+    /// <returns>ハッシュが一致する場合はtrue</returns>
+    Task<bool> ValidateFileHashAsync(string filePath, string expectedHash);
+
+    /// <summary>
+    /// セッションの一時ファイルをクリーンアップ
+    /// </summary>
+    /// <param name="sessionId">セッションID</param>
+    Task CleanupSessionAsync(Guid sessionId);
+
+    /// <summary>
+    /// 古い一時ファイルをクリーンアップ（指定時間以上経過したもの）
+    /// </summary>
+    /// <param name="olderThan">この期間以上古いファイルを削除</param>
+    Task CleanupOldFilesAsync(TimeSpan olderThan);
+}

--- a/src/NonIPFileDelivery/Services/IFrameService.cs
+++ b/src/NonIPFileDelivery/Services/IFrameService.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using NonIPFileDelivery.Models;
 
 namespace NonIPFileDelivery.Services;
 
 public interface IFrameService
 {
+    // 基本フレーム操作
     byte[] SerializeFrame(NonIPFrame frame);
     NonIPFrame? DeserializeFrame(byte[] data);
     NonIPFrame CreateHeartbeatFrame(byte[] sourceMac);
@@ -12,4 +15,18 @@ public interface IFrameService
     NonIPFrame CreateFileTransferFrame(byte[] sourceMac, byte[] destinationMac, FileTransferFrame fileData);
     bool ValidateFrame(NonIPFrame frame, byte[] rawData);
     uint CalculateChecksum(byte[] data);
+    
+    // ACK/NAK再送機構
+    NonIPFrame CreateAckFrame(byte[] sourceMac, byte[] destinationMac, ushort sequenceNumber);
+    NonIPFrame CreateNackFrame(byte[] sourceMac, byte[] destinationMac, ushort sequenceNumber, string reason = "");
+    void RegisterPendingAck(NonIPFrame frame);
+    bool ProcessAck(ushort sequenceNumber);
+    List<NonIPFrame> GetTimedOutFrames();
+    void ClearRetryQueue();
+    (int PendingAcks, int RetryQueueSize) GetStatistics();
+    
+    // フラグメント処理
+    Task<List<NonIPFrame>> CreateFragmentedFramesAsync(byte[] sourceMac, byte[] destinationMac, byte[] data, int maxFragmentSize = 8000, FrameFlags additionalFlags = FrameFlags.None);
+    Task<byte[]?> AddFragmentAndReassembleAsync(NonIPFrame fragmentFrame);
+    Task<double?> GetFragmentProgressAsync(Guid fragmentGroupId);
 }

--- a/src/NonIPFileDelivery/Services/NonIPFileDeliveryService.cs
+++ b/src/NonIPFileDelivery/Services/NonIPFileDeliveryService.cs
@@ -13,6 +13,9 @@ public class NonIPFileDeliveryService
     private readonly INetworkService _networkService;
     private readonly ISecurityService _securityService;
     private readonly IFrameService _frameService;
+    private readonly IFileStorageService _fileStorageService;
+    private readonly ISessionManager _sessionManager;
+    private readonly IRedundancyService? _redundancyService;
     
     private Configuration? _configuration;
     private CancellationTokenSource? _cancellationTokenSource;
@@ -25,13 +28,19 @@ public class NonIPFileDeliveryService
         IConfigurationService configService,
         INetworkService networkService,
         ISecurityService securityService,
-        IFrameService frameService)
+        IFrameService frameService,
+        IFileStorageService fileStorageService,
+        ISessionManager sessionManager,
+        IRedundancyService? redundancyService = null)
     {
         _logger = logger;
         _configService = configService;
         _networkService = networkService;
         _securityService = securityService;
         _frameService = frameService;
+        _fileStorageService = fileStorageService;
+        _sessionManager = sessionManager;
+        _redundancyService = redundancyService;
     }
 
     public async Task<bool> StartAsync(Configuration configuration)
@@ -260,7 +269,7 @@ public class NonIPFileDeliveryService
         }
     }
 
-    private Task ProcessHeartbeatFrame(NonIPFrame frame, string sourceMac)
+    private async Task ProcessHeartbeatFrame(NonIPFrame frame, string sourceMac)
     {
         _logger.Debug($"Heartbeat received from {sourceMac}");
         
@@ -269,24 +278,91 @@ public class NonIPFileDeliveryService
             var payloadText = System.Text.Encoding.UTF8.GetString(frame.Payload);
             _logger.Debug($"Heartbeat data: {payloadText}");
             
-            // ピアのステータスを更新
-            // RedundancyServiceがある場合、ハートビート情報を記録
+            // セッションのハートビート情報を更新
             var sessionId = frame.Header.SessionId;
             if (sessionId != Guid.Empty)
             {
                 _logger.Debug($"Heartbeat for session {sessionId} from {sourceMac}");
+                
                 // セッション管理にハートビート受信を記録
+                var session = await _sessionManager.GetSessionAsync(sessionId);
+                if (session != null)
+                {
+                    await _sessionManager.UpdateSessionActivityAsync(sessionId);
+                    _logger.Debug($"Session activity updated: {sessionId}");
+                }
+                else
+                {
+                    _logger.Debug($"Heartbeat for unknown session: {sessionId}");
+                }
+            }
+            
+            // 冗長性サービスがある場合、ノードステータスを更新
+            if (_redundancyService != null)
+            {
+                try
+                {
+                    // ハートビート情報をパース
+                    var heartbeatInfo = ParseHeartbeatInfo(payloadText);
+                    
+                    if (heartbeatInfo != null)
+                    {
+                        // 冗長性サービスにハートビート情報を記録
+                        // TODO: IRedundancyServiceにRecordHeartbeatメソッドを追加する必要がある
+                        _logger.Debug($"Heartbeat info recorded: NodeId={heartbeatInfo.NodeId}, Status={heartbeatInfo.Status}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warning($"Failed to parse heartbeat info from {sourceMac}: {ex.Message}");
+                }
             }
         }
         catch (Exception ex)
         {
             _logger.Error($"Error processing heartbeat from {sourceMac}", ex);
         }
-        
-        return Task.CompletedTask;
     }
 
-    private Task ProcessDataFrame(NonIPFrame frame, string sourceMac)
+    /// <summary>
+    /// ハートビート情報をパース
+    /// </summary>
+    private HeartbeatInfo? ParseHeartbeatInfo(string payloadText)
+    {
+        try
+        {
+            // 形式: "HEARTBEAT:2025-10-19T12:34:56.789Z:NodeId:Status"
+            var parts = payloadText.Split(':');
+            
+            if (parts.Length >= 2 && parts[0] == "HEARTBEAT")
+            {
+                return new HeartbeatInfo
+                {
+                    Timestamp = DateTime.Parse(parts[1]),
+                    NodeId = parts.Length > 2 ? parts[2] : string.Empty,
+                    Status = parts.Length > 3 ? parts[3] : "Active"
+                };
+            }
+        }
+        catch
+        {
+            // パース失敗時はnullを返す
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// 簡易ハートビート情報クラス
+    /// </summary>
+    private class HeartbeatInfo
+    {
+        public DateTime Timestamp { get; set; }
+        public string NodeId { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+    }
+
+    private async Task ProcessDataFrame(NonIPFrame frame, string sourceMac)
     {
         _logger.Info($"Data frame received from {sourceMac}, size: {frame.Payload.Length} bytes");
         
@@ -295,17 +371,36 @@ public class NonIPFileDeliveryService
             // データペイロードを処理
             var sessionId = frame.Header.SessionId;
             
-            // セッションに関連付けられたデータを処理
-            if (sessionId != Guid.Empty)
+            // セッションを取得または作成
+            if (sessionId == Guid.Empty)
             {
-                _logger.Debug($"Processing data for session {sessionId}");
-                
-                // フラグメント化されたデータの場合は再構築が必要
-                if ((frame.Header.Flags & FrameFlags.FragmentStart) == FrameFlags.FragmentStart ||
-                    (frame.Header.Flags & FrameFlags.FragmentEnd) == FrameFlags.FragmentEnd)
-                {
-                    _logger.Debug($"Fragment detected: FragmentInfo={frame.Header.FragmentInfo?.FragmentIndex}/{frame.Header.FragmentInfo?.TotalFragments}");
-                }
+                _logger.Warning($"Data frame without session ID from {sourceMac}");
+                return;
+            }
+
+            var session = await _sessionManager.GetSessionAsync(sessionId);
+            if (session == null)
+            {
+                _logger.Warning($"Unknown session ID: {sessionId} from {sourceMac}");
+                return;
+            }
+
+            // セッションのアクティビティを更新
+            await _sessionManager.UpdateSessionActivityAsync(sessionId);
+
+            _logger.Debug($"Processing data for session {sessionId}");
+            
+            // フラグメント化されたデータの場合は再構築
+            if ((frame.Header.Flags & FrameFlags.FragmentStart) == FrameFlags.FragmentStart ||
+                (frame.Header.Flags & FrameFlags.FragmentEnd) == FrameFlags.FragmentEnd ||
+                frame.Header.FragmentInfo != null)
+            {
+                await ProcessFragmentedData(frame, session, sourceMac);
+            }
+            else
+            {
+                // 通常のデータフレーム処理
+                await ProcessCompleteDataFrame(frame, session, sourceMac);
             }
             
             // ログ用にペイロードのプレビューを表示
@@ -321,9 +416,68 @@ public class NonIPFileDeliveryService
         {
             _logger.Error($"Error processing data frame from {sourceMac}", ex);
         }
-        
+    }
+
+    /// <summary>
+    /// フラグメント化されたデータフレームを処理
+    /// </summary>
+    private Task ProcessFragmentedData(NonIPFrame frame, SessionInfo session, string sourceMac)
+    {
+        try
+        {
+            var fragmentInfo = frame.Header.FragmentInfo;
+            if (fragmentInfo == null)
+            {
+                _logger.Warning($"Fragment flags set but no FragmentInfo: SessionId={session.SessionId}");
+                return Task.CompletedTask;
+            }
+
+            _logger.Debug($"Fragment detected: {fragmentInfo.FragmentIndex + 1}/{fragmentInfo.TotalFragments}, SessionId={session.SessionId}");
+
+            // フラグメントデータをバッファリング（実装簡略化のため、ここではログのみ）
+            // 本格的な実装では、IFragmentationServiceを使用してフラグメントを再構築
+            _logger.Info($"Fragment {fragmentInfo.FragmentIndex + 1}/{fragmentInfo.TotalFragments} received for session {session.SessionId}");
+
+            // 最終フラグメントの場合
+            if ((frame.Header.Flags & FrameFlags.FragmentEnd) == FrameFlags.FragmentEnd)
+            {
+                _logger.Info($"Final fragment received for session {session.SessionId}, data reconstruction needed");
+                // TODO: フラグメント再構築処理
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"Error processing fragmented data: SessionId={session.SessionId}", ex);
+        }
+
         return Task.CompletedTask;
-    }    private Task ProcessFileTransferFrame(NonIPFrame frame, string sourceMac)
+    }
+
+    /// <summary>
+    /// 完全なデータフレームを処理（上位プロトコルへ転送）
+    /// </summary>
+    private Task ProcessCompleteDataFrame(NonIPFrame frame, SessionInfo session, string sourceMac)
+    {
+        try
+        {
+            _logger.Debug($"Processing complete data frame: SessionId={session.SessionId}, Size={frame.Payload.Length} bytes");
+
+            // プロトコルタイプに応じて適切な処理を実行
+            // 実際の実装では、プロトコルプロキシ（FtpProxy、SftpProxy等）へデータを転送
+            _logger.Info($"Data frame ready for protocol handler: SessionId={session.SessionId}, ConnectionId={frame.Header.ConnectionId}");
+
+            // TODO: プロトコルハンドラへのデータ転送実装
+            // 例: await _protocolHandlerRegistry.RouteDataAsync(session, frame.Payload);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"Error processing complete data frame: SessionId={session.SessionId}", ex);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task ProcessFileTransferFrame(NonIPFrame frame, string sourceMac)
     {
         _logger.Info($"File transfer frame received from {sourceMac}");
         
@@ -332,36 +486,188 @@ public class NonIPFileDeliveryService
             var payloadText = System.Text.Encoding.UTF8.GetString(frame.Payload);
             var fileTransferData = System.Text.Json.JsonSerializer.Deserialize<FileTransferFrame>(payloadText);
             
-            if (fileTransferData != null)
+            if (fileTransferData == null)
             {
-                _logger.Info($"File transfer: {fileTransferData.Operation} - {fileTransferData.FileName} " +
-                           $"(chunk {fileTransferData.ChunkIndex}/{fileTransferData.TotalChunks})");
-                
-                // ファイル転送データの処理
-                var sessionId = frame.Header.SessionId;
-                
-                // チャンクの組み立てとストレージ処理
-                // TODO: 実際のファイルストレージ実装が必要な場合は、IFileStorageServiceを追加
-                _logger.Debug($"File chunk data size: {fileTransferData.ChunkData?.Length ?? 0} bytes");
-                _logger.Debug($"File metadata: Size={fileTransferData.FileSize}, Hash={fileTransferData.FileHash}");
-                
-                // 最終チャンクの場合
-                if (fileTransferData.ChunkIndex == fileTransferData.TotalChunks - 1)
-                {
-                    _logger.Info($"Final chunk received for file: {fileTransferData.FileName}");
-                    // ファイル完成処理
-                }
+                _logger.Warning($"Failed to deserialize file transfer data from {sourceMac}");
+                return;
             }
+
+            _logger.Info($"File transfer: {fileTransferData.Operation} - {fileTransferData.FileName} " +
+                       $"(chunk {fileTransferData.ChunkIndex + 1}/{fileTransferData.TotalChunks})");
+            
+            var sessionId = fileTransferData.SessionId;
+            if (sessionId == Guid.Empty)
+            {
+                sessionId = frame.Header.SessionId;
+            }
+
+            if (sessionId == Guid.Empty)
+            {
+                _logger.Warning($"File transfer without session ID from {sourceMac}");
+                return;
+            }
+
+            // セッションを取得または作成
+            var session = await _sessionManager.GetSessionAsync(sessionId);
+            if (session == null)
+            {
+                _logger.Warning($"Unknown session ID: {sessionId} for file transfer from {sourceMac}");
+                return;
+            }
+
+            // セッションのアクティビティを更新
+            await _sessionManager.UpdateSessionActivityAsync(sessionId);
+
+            // ファイル操作に応じた処理
+            switch (fileTransferData.Operation)
+            {
+                case FileOperation.Start:
+                    _logger.Info($"File transfer started: {fileTransferData.FileName}");
+                    break;
+
+                case FileOperation.Data:
+                    await ProcessFileUpload(fileTransferData, sessionId, sourceMac);
+                    break;
+
+                case FileOperation.End:
+                    _logger.Info($"File transfer completed: {fileTransferData.FileName}");
+                    break;
+
+                case FileOperation.Abort:
+                    _logger.Warning($"File transfer aborted: {fileTransferData.FileName}");
+                    await _fileStorageService.CleanupSessionAsync(sessionId);
+                    break;
+
+                case FileOperation.Resume:
+                    _logger.Info($"File transfer resumed: {fileTransferData.FileName}");
+                    break;
+
+                default:
+                    _logger.Warning($"Unknown file operation: {fileTransferData.Operation} from {sourceMac}");
+                    break;
+            }
+        }
+        catch (System.Text.Json.JsonException jsonEx)
+        {
+            _logger.Error($"JSON deserialization error for file transfer frame from {sourceMac}", jsonEx);
         }
         catch (Exception ex)
         {
             _logger.Error($"Error processing file transfer frame from {sourceMac}", ex);
         }
-        
-        return Task.CompletedTask;
     }
 
-    private Task ProcessControlFrame(NonIPFrame frame, string sourceMac)
+    /// <summary>
+    /// ファイルアップロード処理
+    /// </summary>
+    private async Task ProcessFileUpload(FileTransferFrame fileData, Guid sessionId, string sourceMac)
+    {
+        try
+        {
+            _logger.Debug($"Processing file upload: {fileData.FileName}, Chunk {fileData.ChunkIndex + 1}/{fileData.TotalChunks}");
+
+            if (fileData.ChunkData == null || fileData.ChunkData.Length == 0)
+            {
+                _logger.Warning($"Empty chunk data for file upload: {fileData.FileName}");
+                return;
+            }
+
+            // チャンクを保存
+            var saved = await _fileStorageService.SaveChunkAsync(
+                sessionId, 
+                fileData.FileName, 
+                (int)fileData.ChunkIndex, 
+                (int)fileData.TotalChunks, 
+                fileData.ChunkData);
+
+            if (!saved)
+            {
+                _logger.Error($"Failed to save chunk: {fileData.FileName}, Chunk {fileData.ChunkIndex}");
+                return;
+            }
+
+            _logger.Debug($"Chunk saved: {fileData.FileName}, Chunk {fileData.ChunkIndex + 1}/{fileData.TotalChunks}, Size={fileData.ChunkData.Length} bytes");
+
+            // 全てのチャンクが揃ったかチェック
+            if (await _fileStorageService.AreAllChunksReceivedAsync(sessionId, fileData.FileName, (int)fileData.TotalChunks))
+            {
+                _logger.Info($"All chunks received for file: {fileData.FileName}, starting assembly");
+
+                // ファイルを組み立て
+                var destinationPath = GetDestinationPath(fileData.FileName, sessionId);
+                var assembledPath = await _fileStorageService.AssembleFileAsync(
+                    sessionId, 
+                    fileData.FileName, 
+                    (int)fileData.TotalChunks, 
+                    destinationPath);
+
+                _logger.Info($"File assembled: {assembledPath}");
+
+                // ファイルハッシュを検証
+                if (!string.IsNullOrWhiteSpace(fileData.FileHash))
+                {
+                    var isValid = await _fileStorageService.ValidateFileHashAsync(assembledPath, fileData.FileHash);
+                    
+                    if (isValid)
+                    {
+                        _logger.Info($"File hash validation passed: {fileData.FileName}");
+                    }
+                    else
+                    {
+                        _logger.Error($"File hash validation failed: {fileData.FileName}");
+                        
+                        // ハッシュ検証失敗時はセキュリティ検疫へ
+                        await _securityService.QuarantineFile(assembledPath, "File hash mismatch");
+                        return;
+                    }
+                }
+
+                // 最終的なセキュリティスキャン
+                var fileBytes = await File.ReadAllBytesAsync(assembledPath);
+                var scanResult = await _securityService.ScanData(fileBytes, fileData.FileName);
+                
+                if (!scanResult.IsClean)
+                {
+                    _logger.Warning($"Security threat detected in uploaded file: {fileData.FileName}, Threat: {scanResult.ThreatName}");
+                    await _securityService.QuarantineFile(assembledPath, $"Threat: {scanResult.ThreatName}");
+                }
+                else
+                {
+                    _logger.Info($"File upload completed successfully: {fileData.FileName}, Path: {assembledPath}");
+                }
+
+                // セッションの一時ファイルをクリーンアップ
+                await _fileStorageService.CleanupSessionAsync(sessionId);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"Error processing file upload: {fileData.FileName}", ex);
+        }
+    }
+
+    /// <summary>
+    /// ファイルの最終保存先パスを取得
+    /// </summary>
+    private string GetDestinationPath(string fileName, Guid sessionId)
+    {
+        // 設定から保存先ディレクトリを取得
+        var baseDirectory = _configuration?.Security.QuarantinePath ?? Path.Combine(Path.GetTempPath(), "NonIPFileDelivery", "received");
+        
+        if (!Directory.Exists(baseDirectory))
+        {
+            Directory.CreateDirectory(baseDirectory);
+        }
+
+        // ファイル名の重複を避けるためにセッションIDを含める
+        var safeFileName = Path.GetFileNameWithoutExtension(fileName);
+        var extension = Path.GetExtension(fileName);
+        var uniqueFileName = $"{safeFileName}_{sessionId:N}{extension}";
+
+        return Path.Combine(baseDirectory, uniqueFileName);
+    }
+
+    private async Task ProcessControlFrame(NonIPFrame frame, string sourceMac)
     {
         _logger.Debug($"Control frame received from {sourceMac}");
         
@@ -371,10 +677,24 @@ public class NonIPFileDeliveryService
             var sessionId = frame.Header.SessionId;
             var connectionId = frame.Header.ConnectionId;
             
+            if (sessionId == Guid.Empty)
+            {
+                _logger.Warning($"Control frame without session ID from {sourceMac}");
+                return;
+            }
+
+            // セッションを取得
+            var session = await _sessionManager.GetSessionAsync(sessionId);
+            if (session == null)
+            {
+                _logger.Warning($"Unknown session ID: {sessionId} for control frame from {sourceMac}");
+                return;
+            }
+
             if (frame.Payload.Length > 0)
             {
                 var controlMessage = System.Text.Encoding.UTF8.GetString(frame.Payload);
-                _logger.Debug($"Control message: {controlMessage}");
+                _logger.Debug($"Control message: {controlMessage}, SessionId={sessionId}");
                 
                 // コントロールコマンドの解析と実行
                 // 例: "PAUSE", "RESUME", "CLOSE", "RESET" など
@@ -382,13 +702,29 @@ public class NonIPFileDeliveryService
                 {
                     case "PAUSE":
                         _logger.Info($"Pause request from {sourceMac}, Session={sessionId}");
+                        // セッションを一時停止状態にマーク
+                        // TODO: SessionInfoにState/Status属性を追加する必要がある
                         break;
+                        
                     case "RESUME":
                         _logger.Info($"Resume request from {sourceMac}, Session={sessionId}");
+                        // セッションを再開状態にマーク
                         break;
+                        
                     case "CLOSE":
                         _logger.Info($"Close request from {sourceMac}, Session={sessionId}");
+                        // セッションを終了
+                        await _sessionManager.CloseSessionAsync(sessionId, "Closed by remote request");
+                        // セッションの一時ファイルをクリーンアップ
+                        await _fileStorageService.CleanupSessionAsync(sessionId);
                         break;
+                        
+                    case "RESET":
+                        _logger.Info($"Reset request from {sourceMac}, Session={sessionId}");
+                        // セッションをリセット（一時データ削除）
+                        await _fileStorageService.CleanupSessionAsync(sessionId);
+                        break;
+                        
                     default:
                         _logger.Debug($"Unknown control command: {controlMessage}");
                         break;
@@ -399,8 +735,6 @@ public class NonIPFileDeliveryService
         {
             _logger.Error($"Error processing control frame from {sourceMac}", ex);
         }
-        
-        return Task.CompletedTask;
     }
 
     private async Task SendAcknowledgment(ushort sequenceNumber, string destinationMac)

--- a/src/NonIPWebConfig/Program.cs
+++ b/src/NonIPWebConfig/Program.cs
@@ -55,7 +55,7 @@ builder.Services.AddCors(options =>
 });
 
 // サービス登録
-builder.Services.AddSingleton<IConfigurationService, ConfigurationService>();
+builder.Services.AddSingleton<NonIPWebConfig.Services.ConfigurationService>();
 builder.Services.AddSingleton<NonIPWebConfig.Services.ConfigValidationService>();
 builder.Services.AddSingleton<IAuthService, AuthService>();
 


### PR DESCRIPTION
- IFrameService拡張:
  - CreateAckFrame/CreateNackFrame追加
  - RegisterPendingAck/ProcessAck/GetTimedOutFrames追加
  - ClearRetryQueue/GetStatistics追加
  - フラグメント処理メソッド（既存）も追加

- NonIPFileDeliveryService機能追加:
  - ProcessAckFrame実装: ACK受信処理、FrameService.ProcessAck()呼び出し
  - ProcessNackFrame実装: NACK受信処理、再送要求ログ出力
  - CheckAndRetryTimedOutFrames実装: タイムアウトフレーム検出・再送
  - RunServiceLoopAsync拡張: 2秒ごとに再送チェック実行
  - SendAcknowledgment改修: CreateAckFrame()使用に変更
  - ParseMacAddress追加: MACアドレス文字列解析
  - FrameType.Ack/Nack case追加

- 動作:
  - フレーム送信時にRequireAckフラグが立っている場合、ACK待機
  - 5秒以内にACKが来ない場合、自動再送（最大3回）
  - NACK受信時は警告ログ出力（将来的に即座再送実装予定）

- テスト結果: FrameServiceIntegrationTests 13個全て成功
- ビルド: 0エラー、12警告（非致命的）